### PR TITLE
Add support for the style property to ApexTooltip.

### DIFF
--- a/projects/ng-apexcharts/src/lib/model/apex-types.ts
+++ b/projects/ng-apexcharts/src/lib/model/apex-types.ts
@@ -589,6 +589,10 @@ export interface ApexTooltip {
   intersect?: boolean;
   inverseOrder?: boolean;
   theme?: string;
+  style?: {
+    fontSize?: string;
+    fontFamily?: string;
+  };
   fillSeriesColor?: boolean;
   onDatasetHover?: {
     highlightDAtaSeries?: boolean;


### PR DESCRIPTION
`ApexTooltip` interface support `style` property as can be seen at https://apexcharts.com/docs/options/tooltip/.
In the case when I use `...ApexOptions` interface for options, I get the following TypeScript error: 
`Object literal may only specify known properties, and 'style' does not exist in type 'ApexTooltip'
apex-types.d.ts(11, 5): The expected type comes from property 'tooltip' which is declared here on type 'ApexOptions'`