### PR TITLE
Add markers property for options

### DIFF
--- a/projects/ng-apexcharts/src/lib/model/apex-types.ts
+++ b/projects/ng-apexcharts/src/lib/model/apex-types.ts
@@ -844,5 +844,31 @@ export interface ApexTheme {
   };
 }
 
+interface ApexDiscretePoint {
+  seriesIndex?: number;
+  dataPointIndex?: number;
+  fillColor?: string;
+  strokeColor?: string;
+  size?: number;
+}
+
+export interface ApexMarkers {
+  size?: number;
+  colors?: string[];
+  strokeColor?: string;
+  strokeWidth?: number;
+  strokeOpacity?: number;
+  fillOpacity?: number;
+  discrete?: ApexDiscretePoint[];
+  shape?: 'circle' | 'square';
+  radius?: number;
+  offsetX?: number;
+  offsetY?: number;
+  hover?: {
+    size?: number;
+    sizeOffset?: number;
+  };
+}
+
 export type ChartType = 'line' | 'area' | 'bar' | 'histogram' | 'pie' | 'donut' |
   'radialBar' | 'scatter' | 'bubble' | 'heatmap' | 'candlestick' | 'radar';


### PR DESCRIPTION
`ApexOptions` interface support `markers` property as can be seen at https://apexcharts.com/docs/options/markers/.
In the case when I use `ApexOptions` interface for options, I get the following TypeScript error: `Object literal may only specify known properties, and 'markers' does not exist in type 'ApexOptions'`