### PR TITLE
Fix types for ApexStroke

### DIFF
--- a/projects/ng-apexcharts/src/lib/model/apex-types.ts
+++ b/projects/ng-apexcharts/src/lib/model/apex-types.ts
@@ -212,7 +212,7 @@ export interface ApexStroke {
   show?: boolean;
   curve?: 'smooth' | 'straight' | 'stepline';
   lineCap?: 'butt' | 'square' | 'round';
-  colors?: string;
+  colors?: string[];
   width?: number;
   dashArray?: number | number[];
 }


### PR DESCRIPTION
The colors should have array type string[], not flat string