### PR TITLE
docs: add import {} from "' statement to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ npm install apexcharts ng-apexcharts --save
 ```
 
 3. Add ng-apexcharts-module to imports
-
 ```ts
+import { NgApexchartsModule } from "ng-apexcharts";
+
+...
+
 imports: [
   BrowserModule,
   FormsModule,


### PR DESCRIPTION
Hi there! Thanks for this awesome project.

I was thinking that it could be great if in the README.md is explicitly the `import` statement that refers to the `app.module.ts`. To avoid going into the source code or a Codesandbox example to see from where we have to import.

It might be useful!

