### PR TITLE
allow yaxis label formatter string[] return type for multiline labels

### DIFF
--- a/projects/ng-apexcharts/src/lib/model/apex-types.ts
+++ b/projects/ng-apexcharts/src/lib/model/apex-types.ts
@@ -941,7 +941,7 @@ export interface ApexYAxis {
       fontWeight?: string | number;
       cssClass?: string;
     };
-    formatter?(val: number, opts?: any): string;
+    formatter?(val: number, opts?: any): string | string[];
   };
   axisBorder?: {
     show?: boolean;


### PR DESCRIPTION
As of now, yaxis multiline label via formatter only works if type-checking is disabled via //@ts-ignore.