### PR TITLE
allow for yaxis labels in different colors

### DIFF
--- a/projects/ng-apexcharts/src/lib/model/apex-types.ts
+++ b/projects/ng-apexcharts/src/lib/model/apex-types.ts
@@ -935,7 +935,7 @@ export interface ApexYAxis {
     align?: "left" | "center" | "right";
     padding?: number;
     style?: {
-      colors?: string;
+      colors?: string | string[];
       fontSize?: string;
       fontFamily?: string;
       fontWeight?: string | number;


### PR DESCRIPTION
As of now, yaxis  labels in different colors only works if type-checking is disabled via //@ts-ignore.