### PR TITLE
Improve performance by running outside of ngZone

### DIFF
--- a/projects/ng-apexcharts/src/lib/chart/chart.component.ts
+++ b/projects/ng-apexcharts/src/lib/chart/chart.component.ts
@@ -8,6 +8,7 @@ import {
   SimpleChanges,
   ViewChild,
   NgZone,
+  ChangeDetectionStrategy,
 } from "@angular/core";
 import {
   ApexAnnotations,
@@ -38,6 +39,7 @@ import ApexCharts from "apexcharts";
   selector: "apx-chart",
   templateUrl: "./chart.component.html",
   styleUrls: ["./chart.component.css"],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ChartComponent implements OnInit, OnChanges, OnDestroy {
   @Input() chart: ApexChart;

--- a/projects/ng-apexcharts/src/lib/chart/chart.component.ts
+++ b/projects/ng-apexcharts/src/lib/chart/chart.component.ts
@@ -197,45 +197,45 @@ export class ChartComponent implements OnInit, OnChanges, OnDestroy {
     newSeries: ApexAxisChartSeries | ApexNonAxisChartSeries,
     animate?: boolean
   ) {
-    return this.chartObj.updateSeries(newSeries, animate);
+    return this.ngZone.runOutsideAngular(() => this.chartObj.updateSeries(newSeries, animate));
   }
 
   public appendSeries(
     newSeries: ApexAxisChartSeries | ApexNonAxisChartSeries,
     animate?: boolean
   ) {
-    this.chartObj.appendSeries(newSeries, animate);
+    this.ngZone.runOutsideAngular(() => this.chartObj.appendSeries(newSeries, animate));
   }
 
   public appendData(newData: any[]) {
-    this.chartObj.appendData(newData);
+    this.ngZone.runOutsideAngular(() => this.chartObj.appendData(newData));
   }
 
   public toggleSeries(seriesName: string): any {
-    return this.chartObj.toggleSeries(seriesName);
+    return this.ngZone.runOutsideAngular(() => this.chartObj.toggleSeries(seriesName));
   }
 
   public showSeries(seriesName: string) {
-    this.chartObj.showSeries(seriesName);
+    this.ngZone.runOutsideAngular(() => this.chartObj.showSeries(seriesName));
   }
 
   public hideSeries(seriesName: string) {
-    this.chartObj.hideSeries(seriesName);
+    this.ngZone.runOutsideAngular(() => this.chartObj.hideSeries(seriesName));
   }
 
   public resetSeries() {
-    this.chartObj.resetSeries();
+    this.ngZone.runOutsideAngular(() => this.chartObj.resetSeries());
   }
 
   public zoomX(min: number, max: number) {
-    this.chartObj.zoomX(min, max);
+    this.ngZone.runOutsideAngular(() => this.chartObj.zoomX(min, max));
   }
 
   public toggleDataPointSelection(
     seriesIndex: number,
     dataPointIndex?: number
   ) {
-    this.chartObj.toggleDataPointSelection(seriesIndex, dataPointIndex);
+    this.ngZone.runOutsideAngular(() => this.chartObj.toggleDataPointSelection(seriesIndex, dataPointIndex));
   }
 
   public destroy() {
@@ -243,11 +243,11 @@ export class ChartComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   public setLocale(localeName?: string) {
-    this.chartObj.setLocale(localeName);
+    this.ngZone.runOutsideAngular(() => this.chartObj.setLocale(localeName));
   }
 
   public paper() {
-    this.chartObj.paper();
+    this.ngZone.runOutsideAngular(() => this.chartObj.paper());
   }
 
   public addXaxisAnnotation(
@@ -255,7 +255,7 @@ export class ChartComponent implements OnInit, OnChanges, OnDestroy {
     pushToMemory?: boolean,
     context?: any
   ) {
-    this.chartObj.addXaxisAnnotation(options, pushToMemory, context);
+    this.ngZone.runOutsideAngular(() => this.chartObj.addXaxisAnnotation(options, pushToMemory, context));
   }
 
   public addYaxisAnnotation(
@@ -263,7 +263,7 @@ export class ChartComponent implements OnInit, OnChanges, OnDestroy {
     pushToMemory?: boolean,
     context?: any
   ) {
-    this.chartObj.addYaxisAnnotation(options, pushToMemory, context);
+    this.ngZone.runOutsideAngular(() => this.chartObj.addYaxisAnnotation(options, pushToMemory, context));
   }
 
   public addPointAnnotation(
@@ -271,15 +271,15 @@ export class ChartComponent implements OnInit, OnChanges, OnDestroy {
     pushToMemory?: boolean,
     context?: any
   ) {
-    this.chartObj.addPointAnnotation(options, pushToMemory, context);
+    this.ngZone.runOutsideAngular(() => this.chartObj.addPointAnnotation(options, pushToMemory, context));
   }
 
   public removeAnnotation(id: string, options?: any) {
-    this.chartObj.removeAnnotation(id, options);
+    this.ngZone.runOutsideAngular(() => this.chartObj.removeAnnotation(id, options));
   }
 
   public clearAnnotations(options?: any) {
-    this.chartObj.clearAnnotations(options);
+    this.ngZone.runOutsideAngular(() => this.chartObj.clearAnnotations(options));
   }
 
   public dataURI(options?: any): Promise<void> {

--- a/projects/ng-apexcharts/src/lib/chart/chart.component.ts
+++ b/projects/ng-apexcharts/src/lib/chart/chart.component.ts
@@ -7,6 +7,7 @@ import {
   OnDestroy,
   SimpleChanges,
   ViewChild,
+  NgZone,
 } from "@angular/core";
 import {
   ApexAnnotations,
@@ -65,6 +66,10 @@ export class ChartComponent implements OnInit, OnChanges, OnDestroy {
 
   @ViewChild("chart", { static: true }) private chartElement: ElementRef;
   private chartObj: any;
+
+  constructor(private ngZone: NgZone) {
+
+  }
 
   ngOnInit() {
     asapScheduler.schedule(() => {
@@ -163,13 +168,15 @@ export class ChartComponent implements OnInit, OnChanges, OnDestroy {
       this.chartObj.destroy();
     }
 
-    this.chartObj = new ApexCharts(this.chartElement.nativeElement, options);
-
+    this.ngZone.runOutsideAngular(() => {
+      this.chartObj = new ApexCharts(this.chartElement.nativeElement, options);
+    });
+    
     this.render();
   }
 
   public render(): Promise<void> {
-    return this.chartObj.render();
+    return this.ngZone.runOutsideAngular(() => this.chartObj.render());
   }
 
   public updateOptions(
@@ -178,19 +185,19 @@ export class ChartComponent implements OnInit, OnChanges, OnDestroy {
     animate?: boolean,
     updateSyncedCharts?: boolean
   ): Promise<void> {
-    return this.chartObj.updateOptions(
+    return this.ngZone.runOutsideAngular(() => this.chartObj.updateOptions(
       options,
       redrawPaths,
       animate,
       updateSyncedCharts
-    );
+    ));
   }
 
   public updateSeries(
     newSeries: ApexAxisChartSeries | ApexNonAxisChartSeries,
     animate?: boolean
   ) {
-    this.chartObj.updateSeries(newSeries, animate);
+    return this.chartObj.updateSeries(newSeries, animate);
   }
 
   public appendSeries(

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -16,7 +16,7 @@
                 }}"
            [title]="{ text: form.value.title }" [autoUpdateSeries]="false"></apx-chart>
 
-<form [formGroup]="form">
+<form [formGroup]="form" [class.tes]="changeDet()">
   Title: <input type="text" formControlName="title"><br>
   Height: <input type="number" formControlName="height"><br>
   Type: <select formControlName="type">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -19,6 +19,11 @@ export class AppComponent {
   public get xaxis() {
     return this.form.get('xaxis') as FormArray;
   }
+  private det = 0;
+  changeDet(): boolean{
+    console.log(`change${this.det++}`);
+    return false;
+  }
 
   constructor() {
     this.form = new FormGroup({


### PR DESCRIPTION
In order to do the "magic" of change detection, angular uses zone.js. This patches a lot of functions, like hover, requestAnimationFrame and others and tells angular to rerun changeDetection.

Right now the chart runs inside the angular zone which means that all requestAnimationFrame, hover for tooltips, clicks, etc. will trigger change detection. I don't think they should as this causes a big hit in performance for something that is not really needed since apexchart.js already runs without angular intervention.

To get an idea, see the console output, which says how many change detection cycles have ran:

Prior to this change, pressing the button add series:
![Screenshot_3](https://user-images.githubusercontent.com/32216320/155773130-32bf11ff-a29d-4597-86fe-39ed6d08912b.png)
After this change:
![Screenshot_1](https://user-images.githubusercontent.com/32216320/155773149-71cf4c5e-1218-488f-b532-718e4966f83f.png)

To solve this I run the rendering of the chart outside of the angular zone which means that it will not detect these calls.

However I am not sure of the following:

- [ ] Do functions like updateSeries, addSeries, etc. trigger rendering themselves? If so, we should also run them outside the angular zone
- [ ] Should we also add OnPush to the component? This would further increase performance, since it would only check for changes on the component if an input reference changed. Do we only need to know if the reference changed or also if a property has changed?