### PR TITLE
charts re-render after initial render

### DIFF
--- a/projects/ng-apexcharts/src/lib/chart/chart.component.ts
+++ b/projects/ng-apexcharts/src/lib/chart/chart.component.ts
@@ -3,7 +3,6 @@ import {
   ElementRef,
   Input,
   OnChanges,
-  OnInit,
   OnDestroy,
   SimpleChanges,
   ViewChild,
@@ -42,7 +41,7 @@ import ApexCharts from "apexcharts";
   styleUrls: ["./chart.component.css"],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ChartComponent implements OnInit, OnChanges, OnDestroy {
+export class ChartComponent implements OnChanges, OnDestroy {
   @Input() chart: ApexChart;
   @Input() annotations: ApexAnnotations;
   @Input() colors: any[];
@@ -73,12 +72,6 @@ export class ChartComponent implements OnInit, OnChanges, OnDestroy {
 
   constructor(private ngZone: NgZone) {
 
-  }
-
-  ngOnInit() {
-    asapScheduler.schedule(() => {
-      this.createElement();
-    });
   }
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
It also fixes #152.

    Angular execute hooks in following sequence
    1. ngOnChanges called  before ngOnInit
    2. ngOnInit called once after the first ngOnChanges
    3. Further ngOnChanges is called if there are any sub-sequent changes in component inputs

    In first load, render function (through createElement) is called twice (RC - seq.1 & 2 both executed)

    For details, https://angular.io/guide/lifecycle-hooks